### PR TITLE
SPMVP-2424: Fix __PUBLICATION_NAME__ view update error

### DIFF
--- a/src/components/UserDialog/UserDialog.vue
+++ b/src/components/UserDialog/UserDialog.vue
@@ -43,11 +43,11 @@ const emit = defineEmits<{
 
 const currentType = ref('')
 const type = toRef(props, 'type')
-const result: Record<string, string> = {
+const result = computed<Record<string, string>>(() => ({
   __PAID_PLAN__: props.subscriberData?.subscription?.interval ?? '',
   __RENEWS_DATE__: props.subscriberData?.subscription?.renew_on ?? '',
-  __PUBLICATION_NAME__: props.siteData?.name,
-}
+  __PUBLICATION_NAME__: props.siteData?.name ?? '',
+}))
 
 watch(
   type,
@@ -76,7 +76,7 @@ const currentData = computed(() => {
   return {
     title: current.title,
     sub: current.sub.replace(/\b(__PAID_PLAN__|__RENEWS_DATE__|__PUBLICATION_NAME__)\b/g, (match) => {
-      return result[match]
+      return result.value[match]
     }),
     button: current.button,
   }


### PR DESCRIPTION
When the page is refreshed, the initial value of `workspaceStore.currentWorkspace.name` is `undefined`

![image](https://user-images.githubusercontent.com/37400982/168766009-fcbbaa60-f5fa-45a9-b82c-8fb4099c551a.png)


And the view is not updated correctly after the props update

fixed:

![image](https://user-images.githubusercontent.com/37400982/168766155-08fd5c14-d0db-4252-9830-5d54908f3cf6.png)
