### PR TITLE
[SPMVP-2722] Trigger signup/signin with Enter

### DIFF
--- a/src/components/Paywall/Paywall.vue
+++ b/src/components/Paywall/Paywall.vue
@@ -51,7 +51,7 @@ const isUpgrade = computed(() => {
             type="email"
             placeholder="Email Address"
             class="text-inputs layer-1 mb-3 h-12 w-full bg-transparent px-4 pt-3.5 pb-[0.8rem] text-zinc-500 md:mb-0 md:mr-[1.125rem] md:max-w-[47.6%]"
-            @keydown.enter="emit('click', email)"
+            @keyup.enter="emit('click', email)"
           />
           <Button
             :text="currentData.button"

--- a/src/components/UserDialog/components/LoginInEmail.vue
+++ b/src/components/UserDialog/components/LoginInEmail.vue
@@ -29,7 +29,7 @@ const email = ref('')
       type="text"
       placeholder="Email address"
       class="text-inputs h-12 w-full border border-zinc-700 bg-transparent px-4 py-3"
-      @keydown.enter="emit('apply', { email })"
+      @keyup.enter="emit('apply', { email })"
     />
   </div>
 


### PR DESCRIPTION
https://storipress-media.atlassian.net/browse/SPMVP-2722

### 🎩 Instructions

1. Open Storybook and `Paywall` category
2. Test the `free` page, check that key in(up) the key:`enter` on the input field, and click the `sign up` button is the same behavior
2. Test the `paid` page, check that key in(up) the key:`enter` on the input field, and click the `sign up` button is the same behavior
3. Change to `UserDialog`
4. Test the `Email Login` page, check that key in(up) the key:`enter` on the input field, and click the `sign in` button is the same behavior