### PR TITLE
[SPMVP-3183] fix referrer parameter for subscriber sign-in and sign-up

### DIFF
--- a/src/composables/auth.ts
+++ b/src/composables/auth.ts
@@ -49,8 +49,8 @@ export function useAuth(tokenRef: Ref<string | null> = useStorage('test-token', 
     try {
       const result = await signUpSubscriberMutate({
         email,
-        referer: location.origin,
-        from: document.referrer,
+        referer: document.referrer || location.origin,
+        from: location.href,
       })
       if (result?.data.signUpSubscriber) {
         tokenRef.value = result?.data.signUpSubscriber


### PR DESCRIPTION
https://storipress-media.atlassian.net/browse/SPMVP-3183

### 🎩 Instructions

1. Open Storybook and `Paywall` category
2. Test the `PaywallSystem` page
3. Input an email and click the `Sign Up`
4. Check the related API request
5. The variables in the payload tab should like below:
```
variables
  email: "YOUR INPUT"
  from: "http://localhost:6006/iframe.html?viewMode=story&id=paywallsystem--default&args="
  referer: "http://localhost:6006/"
```