### PR TITLE
[SPMVP-3364] fix: dialog shouldn't close after user update newsletter

### DIFF
--- a/src/PaywallSystem.vue
+++ b/src/PaywallSystem.vue
@@ -135,7 +135,7 @@ const handlers: Record<ApplyHandlerType, UserDialogHandler> = {
   cancel: cancelSubscription as UserDialogHandler,
 }
 
-const onApplyHandler = async ({ type, ...params }: UserDialogParams) => {
+const onApplyHandler = async ({ type, ...params }: UserDialogParams, showDialog: boolean) => {
   const result = await handlers[type](params)
   if (UPDATE_DIALOG.has(dialogType)) {
     await refetchSubscriber()
@@ -151,7 +151,7 @@ const onApplyHandler = async ({ type, ...params }: UserDialogParams) => {
       dialogType = 'accountPlan'
     } else {
       modalVisible = true
-      visible = false
+      visible = showDialog
     }
   } else if (type === 'login' && articleType !== 'upgrade' && 'email' in params) {
     visible = false

--- a/src/components/UserDialog/UserDialog.vue
+++ b/src/components/UserDialog/UserDialog.vue
@@ -37,7 +37,7 @@ const props = defineProps({
   },
 })
 const emit = defineEmits<{
-  (event: 'applyHandler', params: UserDialogParams): void
+  (event: 'applyHandler', params: UserDialogParams, showDialog: boolean): void
   (event: 'update:type', type: UserDialogType | ''): void
 }>()
 
@@ -114,7 +114,7 @@ const onChangeDialogType = (type: UserDialogType | '', show: boolean) => {
             v-bind="{ siteData, subscriberData, type, showBilling, button: currentData.button }"
             @change-dialog-type="onChangeDialogType"
             @close="receiveProps.onCloseDialog()"
-            @apply="(params: UserDialogParams) => emit('applyHandler', params)"
+            @apply="(params: UserDialogParams, showDialog = false) => emit('applyHandler', params, showDialog)"
           />
         </slot>
       </div>

--- a/src/components/UserDialog/components/ManageAccount.vue
+++ b/src/components/UserDialog/components/ManageAccount.vue
@@ -16,7 +16,7 @@ const props = defineProps({
 })
 const emit = defineEmits<{
   (event: 'changeDialogType', type: UserDialogType, showBilling: boolean): void
-  (event: 'apply', params: UserDialogParams): void
+  (event: 'apply', params: UserDialogParams, showDialog?: boolean): void
 }>()
 
 const subscriptionPlan = computed(() => {
@@ -84,7 +84,7 @@ const onChangeDialogType = (showBilling = false) => {
             :checked="subscriberData?.newsletter"
             type="simple"
             color="bg-green-600"
-            @click="emit('apply', { type: 'update', input: { newsletter: !subscriberData?.newsletter } })"
+            @click="emit('apply', { type: 'update', input: { newsletter: !subscriberData?.newsletter } }, true)"
           />
         </template>
       </ListItem>


### PR DESCRIPTION
[SPMVP-3364](https://storipress-media.atlassian.net/browse/SPMVP-3364)

### 🎩 Instructions
1. Open account setting
2. Click email newsletter toggle to update
3. Toggle status updates and dialog not closed 