### PR TITLE
fix(paywall): hide scroll [SPMVP-4889]

### DIFF
--- a/src/components/Paywall/Paywall.vue
+++ b/src/components/Paywall/Paywall.vue
@@ -55,7 +55,7 @@ watch([() => props.defaultEmail, emailRef], () => {
 <template>
   <div v-if="type !== 'hide'" class="flex w-full justify-center">
     <div
-      class="layer-2 w-full overflow-scroll rounded-t-2xl bg-zinc-50 px-6 py-5 md:py-8 md:px-10 lg:h-fit lg:w-[70vw] lg:min-w-[45rem] lg:max-w-[60rem] lg:rounded-2xl"
+      class="layer-2 w-full overflow-hidden rounded-t-2xl bg-zinc-50 px-6 py-5 md:py-8 md:px-10 lg:h-fit lg:w-[70vw] lg:min-w-[45rem] lg:max-w-[60rem] lg:rounded-2xl"
     >
       <div class="mb-4 text-zinc-700 md:mr-4 md:mb-11">
         <div class="text-display-large font-black md:text-[2.625rem] md:leading-[1.05]" v-html="currentData.title" />


### PR DESCRIPTION
[SPMVP-4889](https://storipress-media.atlassian.net/browse/SPMVP-4889)
修正如果在電腦系統設定總是顯示捲軸時，paywall 會顯示 scroll 的問題

before:
<img width="869" alt="截圖 2023-03-17 上午9 13 26" src="https://user-images.githubusercontent.com/35054329/225787058-1738c3c8-54d5-4b01-87d4-97780d4157bd.png">

after:
<img width="869" alt="截圖 2023-03-17 上午9 12 58" src="https://user-images.githubusercontent.com/35054329/225787013-5ab3d325-eebc-4aac-8994-880317ff0b2f.png">


[SPMVP-4889]: https://storipress-media.atlassian.net/browse/SPMVP-4889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ