### PR TITLE
fix: sign-in/sign-up form shows success even if API was not sent successfully [SPMVP-6214]

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0 # disable shallow checkout, chromatic need git history
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
       - name: publish package
         run: |
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
       - name: publish package
         run: |

--- a/.github/workflows/static-analyzer.yml
+++ b/.github/workflows/static-analyzer.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
       - run: yarn
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
       - run: yarn
       - run: yarn test --coverage

--- a/src/PaywallSystem.vue
+++ b/src/PaywallSystem.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { ApolloError } from '@apollo/client/core'
 import { useEventBus, useVModel } from '@vueuse/core'
 import { computed, provide, ref, watch } from 'vue'
 import type {
@@ -91,11 +92,15 @@ const profile = computed(() => {
 async function handleSignup(email: string, customArticleType?: string) {
   const checkExistEmailAndShowDialog = async (showDialogType: UserDialogType) => {
     const result = await onSignup(email)
-    if (result && result?.data.signUpSubscriber) {
+    if (result instanceof ApolloError) {
+      const result = await onLogin({ email })
+      if (!result) dialogType.value = 'error'
+      modalVisible.value = true
+    } else if (result && result?.data.signUpSubscriber) {
       dialogType.value = showDialogType
       visible.value = true
     } else {
-      onLogin({ email })
+      dialogType.value = 'error'
       modalVisible.value = true
     }
   }
@@ -201,6 +206,8 @@ function onConfirmModal() {
       dialogType.value = 'shareToTwitter'
       modalVisible.value = true
     }, 300)
+  } else if (dialogType.value === 'error') {
+    dialogType.value = 'welcome'
   }
 }
 

--- a/src/components/UserDialog/UserDialog.vue
+++ b/src/components/UserDialog/UserDialog.vue
@@ -77,6 +77,7 @@ const dialogMap: Record<UserDialogType | '', Component | undefined> = {
   subscribe: AccountDetail,
   confirmation: OnlyButton,
   shareToTwitter: undefined,
+  error: undefined,
   '': undefined,
 }
 

--- a/src/components/UserDialog/definition.ts
+++ b/src/components/UserDialog/definition.ts
@@ -11,6 +11,7 @@ export type UserDialogType =
   | 'subscribe'
   | 'confirmation'
   | 'shareToTwitter'
+  | 'error'
 
 export interface SubscriberInput {
   email?: string

--- a/src/composables/auth.ts
+++ b/src/composables/auth.ts
@@ -2,6 +2,7 @@ import { useMutation } from '@vue/apollo-composable'
 import { useStorage } from '@vueuse/core'
 import gql from 'graphql-tag'
 import { type Ref, computed } from 'vue'
+import { ApolloError } from '@apollo/client/core'
 
 export type AuthAPI = ReturnType<typeof useAuth>
 
@@ -58,6 +59,12 @@ export function useAuth(tokenRef: Ref<string | null> = useStorage('test-token', 
         return result
       }
     } catch (e) {
+      if (e instanceof ApolloError) {
+        const errorMessage = e.graphQLErrors[0]?.message
+        if (errorMessage === 'Bad Request.') {
+          return e
+        }
+      }
       // eslint-disable-next-line no-console
       console.log('e: ', e)
     }

--- a/src/modal-text.ts
+++ b/src/modal-text.ts
@@ -23,4 +23,9 @@ export const modalTexts: Record<string, ModalText> = {
     title: 'Spread the word',
     sub: 'If you want to help __PUBLICATION_NAME__ even more, share your reason for subscribing.',
   },
+  error: {
+    title: 'An error occurred',
+    sub: 'Please retry later.',
+    button: 'Close',
+  },
 }


### PR DESCRIPTION
## Jira
https://storipress-media.atlassian.net/browse/SPMVP-6214

[//]: # 'This template is for logical bug fixing, e.g. button functionality, link, js condition'
[//]: # 'Put the related jira links here'
[//]: # 'Please ensure there has reproduce steps and expected/actual result in the Jira'

## Root cause
subscribe 的 submit button 按下後會呼叫 paywall 的 handleSignup，handleSignup 這邊只有判斷如果是已經註冊過的使用者在呼叫 login 後就直接顯示 dialog，並沒有判斷是否有呼叫成功

[//]: # 'Why the bug happen?'

## Purpose
修正即使未登入成功仍會顯示成功訊息

[//]: # 'Please describe how the issue will affect user, e.g.'
[//]: # '- Fix the schedule button so publisher can schedule article correctly'
[//]: # '- Fix the shifting in Kanban when dragging a card to give publisher better experience'
[//]: # (User should be one of "reader" {who read publisher's articles}, "publisher" {our users}, "developer" {us})

### For who

- [x] reader-facing?
- [ ] publisher-facing?
- [ ] developer-facing?

## How did you fix it?
如果呼叫 sign-in/sign-up api 未成功，顯示錯誤提示視窗

[//]: # 'Give a brief for the changes you made'

## Production deployment notes

[//]: # 'Please describe the production deployment notes, e.g. this changes depend on other API or module change'

## 🎩 Tophat

Do a thorough 🎩. What is [tophatting](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md_)?

Consider testing:

- Existing functionality which could break due to your changes (e.g. global changes)
- New functionality being introduced. Ensure it meets intended behavior
- All different permutations (flows, states, conditions, etc) that are possible
- If you are modifying something which is used in multiple places, 🎩 all affected areas not just what you intend to change

### 🎩 Instructions

[//]: # "If it's complex, consider put a screen record here"

https://github.com/storipress/paywall-component/assets/35054329/926f964e-140d-4029-b757-d8934d2066af


## Related PRs

[//]: # 'Put the related PRs here, e.g. PR in core-component'

## Checklist before requesting review

- [ ] I have done a self-review of my own code (comment on code is not required but recommended)
- [ ] I did the Tophat steps and confirm the issue fixed
- [ ] I have confirmed there is no issue reported by Static Analyzer (Please double check for custom class. For other issues, if you think it's ignorable, please add `// eslint-ignore-next-line <rule name>` on it)
- [ ] I have confirmed there is no deepsource issue (if you think it's ignorable, please explain why and add a [`skipcq` comment](https://deepsource.io/blog/releases-silence-issues-in-code/))
- [ ] I confirmed that the unit test is passed (if you break it, please fix it in this PR)
- [ ] I confirmed that I didn't break E2E test (if you break it, please fix it or create a new Jira)

## Emoji Guide

<!-- from https://developers.soundcloud.com/blog/pr-templates-for-effective-pull-requests -->

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |

## Gif (optional)

![image](https://i.gifer.com/origin/b8/b842107e63c67d5674d17e0f576274fa.gif)
